### PR TITLE
fix: replace bare except clauses with except Exception

### DIFF
--- a/sdgsystem/buffer.py
+++ b/sdgsystem/buffer.py
@@ -72,7 +72,7 @@ class TaskBuffer:
 
             if usage_counter:
                 usage_counter.load_from_dict(usage)
-        except:
+        except Exception:
             pass
 
         # resize detail_progress to match the current total if different from loaded total
@@ -82,7 +82,7 @@ class TaskBuffer:
         results: Iterable[Any] = []
         try:
             results: Iterable[Any] = load_json(self.result_path)
-        except:
+        except Exception:
             pass
 
         return results

--- a/sdgsystem/dataset/process.py
+++ b/sdgsystem/dataset/process.py
@@ -62,7 +62,7 @@ class DataFilter:
         if match:
             try:
                 return json.loads(match.group().strip())
-            except:
+            except Exception:
                 return {"Relevance": 5, "Correctness": 5, "Helpfulness": 5, "Clarity": 5, "Difficulty": 5}
         return {"Relevance": 5, "Correctness": 5, "Helpfulness": 5, "Clarity": 5, "Difficulty": 5}
 
@@ -141,6 +141,6 @@ class Formatter:
             try:
                 result = json.loads(match.group().strip())
                 return result
-            except:
+            except Exception:
                 return {"input": None, "output": None}
         return {"input": None, "output": None}

--- a/sdgsystem/generation/base.py
+++ b/sdgsystem/generation/base.py
@@ -93,7 +93,7 @@ class BaseGenerator:
                             parsed_samples.append(sample)
                         else:
                             parse_failed_count += 1
-                    except:
+                    except Exception:
                         parse_failed_count += 1
             else:
                 # already sample in dictionary type

--- a/sdgsystem/models/postprocess/majority_voting.py
+++ b/sdgsystem/models/postprocess/majority_voting.py
@@ -244,7 +244,7 @@ class BaseVoting(ABC):
             mode_value = mode(answers)
             mode_ids = [idx for idx, value in enumerate(answers) if value == mode_value]
             selected_idx = random.choice(mode_ids) if mode_ids else None
-        except:
+        except Exception:
             mode_value, selected_idx, mode_ids = None, None, None
         
         if usage_counter:


### PR DESCRIPTION
Replace 6 bare `except:` across 4 files with `except Exception:` to avoid catching `SystemExit`/`KeyboardInterrupt` during data generation.