### PR TITLE
fix: correct typo in ModelUsageCounter log message

### DIFF
--- a/sdgsystem/models/usage_counter.py
+++ b/sdgsystem/models/usage_counter.py
@@ -107,7 +107,7 @@ class ModelUsageCounter:
             remain_token_anticipation = int(avg_token * self.remain)
             remain_time_anticipation = avg_time * self.remain
 
-            logger.info(f"[{self.name} Usage]: completed={self.completed}, token={self.token}, time={self.time:.2f} || remain={self.remain}, remain_token_anticipation={remain_token_anticipation}, remain_time_anticipatioin={remain_time_anticipation:.2f}")
+            logger.info(f"[{self.name} Usage]: completed={self.completed}, token={self.token}, time={self.time:.2f} || remain={self.remain}, remain_token_anticipation={remain_token_anticipation}, remain_time_anticipation={remain_time_anticipation:.2f}")
 
         # call callback outside of lock to avoid deadlock
         if self._on_update:


### PR DESCRIPTION
## Problem

`ModelUsageCounter.estimate_usage()` logs a progress line after every batch.  The field name in that log message contained a typo:

```
remain_time_anticipatioin=...   # ← extra 'i' before 'on'
```

This is a cosmetic issue, but it:
- produces misleading output when operators tail the logs to monitor a long generation run
- breaks any log-parsing script or monitoring rule that matches on the field name
- causes confusion when comparing the log key against the variable name `remain_time_anticipation` (which is spelled correctly in the code)

## Fix

Rename the log key to match the variable:

```
remain_time_anticipation=...   # ✓
```

One-character change, zero functional impact.

## Files changed

- `sdgsystem/models/usage_counter.py`
