### PR TITLE
fix: replace bare except clauses with except Exception in TaskBuffer

### DIFF
--- a/sdgsystem/buffer.py
+++ b/sdgsystem/buffer.py
@@ -72,7 +72,7 @@ class TaskBuffer:
 
             if usage_counter:
                 usage_counter.load_from_dict(usage)
-        except:
+        except Exception:
             pass
 
         # resize detail_progress to match the current total if different from loaded total
@@ -82,7 +82,7 @@ class TaskBuffer:
         results: Iterable[Any] = []
         try:
             results: Iterable[Any] = load_json(self.result_path)
-        except:
+        except Exception:
             pass
 
         return results


### PR DESCRIPTION
## Problem

`TaskBuffer.load()` in `sdgsystem/buffer.py` contains two bare `except:` clauses:

```python
try:
    usage = load_json(self.usage_path)
    ...
except:          # ← catches everything, including KeyboardInterrupt
    pass

try:
    results = load_json(self.result_path)
except:          # ← same issue
    pass
```

A bare `except:` catches **all** exceptions, including `BaseException` subclasses such as:

| Exception | Effect when swallowed |
|---|---|
| `KeyboardInterrupt` | Ctrl-C during a long generation run is silently ignored |
| `SystemExit` | `sys.exit()` calls fail to terminate the process |
| `GeneratorExit` | Generator cleanup is suppressed |
| `MemoryError` | OOM conditions pass unnoticed |

In practice, a user hitting Ctrl-C while a run is loading from a checkpoint may find the process unresponsive — it swallowed the interrupt.

## Fix

Replace both bare `except:` with `except Exception:`.  `Exception` still covers every expected failure mode for these blocks (missing file, permission error, JSON parse error), while allowing `BaseException` subclasses to propagate normally.

```python
except Exception:   # covers IOError, JSONDecodeError, etc.
    pass
```

## Files changed

- `sdgsystem/buffer.py`
